### PR TITLE
Fix styles with Rubocop, Fix Rakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you would like to contribute then
 
 ## Credits
 
-- [Ye Lin Aung](https://github.com/yelinaung) for his awesome [mmfont](https://githubcom/yelinaung/mmfont) gem.
+- [Ye Lin Aung](https://github.com/yelinaung) for his awesome [mmfont](https://github.com/yelinaung/mmfont) gem.
 
 - [Thura Hlaing](https://github.com/trhura) for his excellent [paytan](https://github.com/trhura/paytan) converter generator.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,11 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
-desc "Run Tests!"
-task :test,[:environment]  do|t,args|
-	system "ruby spec/*_spec.rb"
+desc 'Run Tests!'
+Rake::TestTask.new do |t|
+  t.libs << 'lib'
+  t.libs << 'spec'
+  system 'ruby spec/*_spec.rb'
 end
+
+task default: :test

--- a/lib/generators/mmunicode_rails/initializer_generator.rb
+++ b/lib/generators/mmunicode_rails/initializer_generator.rb
@@ -1,15 +1,14 @@
 module MmunicodeRails
   module Generators
+    # Generator
     class InitializerGenerator < ::Rails::Generators::Base
-
-      source_root File.expand_path("../../templates", __FILE__)
+      source_root File.expand_path('../../templates', __FILE__)
 
       desc 'Creates MmunicodeRails initializer.'
 
       def copy_initializer
         copy_file 'mmunicode_rails.rb', 'config/initializers/mmunicode_rails.rb'
       end
-
     end
   end
 end

--- a/lib/generators/templates/mmunicode_rails.rb
+++ b/lib/generators/templates/mmunicode_rails.rb
@@ -1,2 +1,3 @@
-puts "Inserting middleware mmunicode"
-Rails.application.config.middleware.insert_before(ActionDispatch::ParamsParser,MmunicodeRails::RackMmunicode)
+puts 'Inserting middleware mmunicode'
+Rails.application.config.middleware.insert_before(ActionDispatch::ParamsParser,
+                                                  MmunicodeRails::RackMmunicode)

--- a/lib/mmunicode_rails.rb
+++ b/lib/mmunicode_rails.rb
@@ -1,9 +1,8 @@
-require "mmunicode_rails/version"
+require 'mmunicode_rails/version'
 require 'rack'
 
 module MmunicodeRails
-
-	module Core		
+	module Core
 	    def uni512zg1(input_text)
 	      return input_text unless detect_font(input_text) == :uni
 	      output_text = input_text

--- a/lib/mmunicode_rails/version.rb
+++ b/lib/mmunicode_rails/version.rb
@@ -1,3 +1,4 @@
+# Version
 module MmunicodeRails
-  VERSION = "0.4.5"
+  VERSION = '0.4.5'
 end


### PR DESCRIPTION
Hi,

I've run a quick check with [rubocop](https://github.com/bbatsov/rubocop) (You should check it out, it's awesome) on some files and tried to fixed. 
You might have various style on how your codes look alike but excuse my snarkiness, I am very obsessed with code styles. 

And I have made some changes to Rakefile to be able to run the test and set default task to `test`. 

```
λ ~:mmunicode_rails rake
/Users/yelinaung/work/ruby/mmunicode_rails/lib/mmunicode_rails.rb:44: warning: regular expression has redundant nested repeat operator '*'
/Users/yelinaung/.rvm/gems/ruby-2.2.0/gems/activesupport-3.2.21/lib/active_support/values/time_zone.rb:270: warning: circular argument reference - now
-- create_table(:posts)
   -> 0.0055s
-- initialize_schema_migrations_table()
   -> 0.0006s
-- assume_migrated_upto_version(0, ["db/migrate"])
   -> 0.0002s
-- create_table(:books)
   -> 0.0005s
-- initialize_schema_migrations_table()
   -> 0.0001s
-- assume_migrated_upto_version(0, ["db/migrate"])
   -> 0.0001s
Run options: --seed 22032

# Running:

.....

Finished in 0.010257s, 487.4720 runs/s, 779.9552 assertions/s.

5 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```

You might wanna integrate with Travis for CI. Kudos for making this happen.
