### PR TITLE
Fixed README.md license header not rendering due to misalignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,6 @@ If you would like to contribute then
 
 - [Green Like Orange](https://github.com/greenlikeorange) for his great font detection code in [knayi](https://github.com/greenlikeorange/knayi-myscript) script.
 
-##LICENSE
+## LICENSE
 
 The project is under GNU LESSER GENERAL PUBLIC LICENSE. You can view the license terms [here](LICENSE.txt).


### PR DESCRIPTION
I have added a commit that fixes the README.md License header is misaligned.