### PR TITLE
Removed  deprecated `ActionDispatch::ParamsParser` to support rails 5.x +

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is by no means a complete solution. It's just a convenient helper gem.
 
 "mmunicode_rails" lets you convert you rails app input data to Myanmar Unicode regardless of which fonts the users used. 
 
-Supported for rails 4.x and 3.x
+Supported for rails 3.x, 4.x, 5.x and 6.x
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ class PersonController < ApplicationController
 	before_filter :change_name_to_unicode
 
 	private
-		def change_name_to_unicode
-			zg12uni51(person_params[:name]) if person_params[:name]
-		end
+	def change_name_to_unicode
+	  zg12uni51(person_params[:name]) if person_params[:name]
+	end
 end
 ```
 

--- a/lib/generators/templates/mmunicode_rails.rb
+++ b/lib/generators/templates/mmunicode_rails.rb
@@ -1,3 +1,2 @@
 puts 'Inserting middleware mmunicode'
-Rails.application.config.middleware.insert_before(ActionDispatch::ParamsParser,
-                                                  MmunicodeRails::RackMmunicode)
+Rails.application.config.middleware.insert_before(MmunicodeRails::RackMmunicode)


### PR DESCRIPTION
Update readme formatting and removed  deprecated `ActionDispatch::ParamsParser` to support rails 5.x +